### PR TITLE
Move extension to the main area

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ Currently the pref pass-thru from the jupyterlab frontend to the underlying cond
 
 ```typescript
 const prefDefault: IPreferences = {
-  apiUrl: "http://localhost:5000/conda-store/",
-  authMethod: "cookie",
-  loginUrl: "http://localhost:5000/conda-store/login?next=",
-  authToken: "",
-  styleType: "grayscale",
+  apiUrl: 'http://localhost:5000/conda-store/',
+  authMethod: 'cookie',
+  loginUrl: 'http://localhost:5000/conda-store/login?next=',
+  authToken: '',
+  styleType: 'grayscale',
   showLoginIcon: true
-}
+};
 ```
 
 Once the values are changed as you like, follow the rest of the "Development install" instruction to build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Currently the pref pass-thru from the jupyterlab frontend to the underlying cond
 const prefDefault: IPreferences = {
   apiUrl: "http://localhost:5000/conda-store/",
   authMethod: "cookie",
-  loginUrl: "http://localhost:5000/conda-store/login?next",
+  loginUrl: "http://localhost:5000/conda-store/login?next=",
   authToken: "",
   styleType: "grayscale",
   showLoginIcon: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ const prefDefault: IPreferences = {
   authMethod: "cookie",
   loginUrl: "http://localhost:5000/conda-store/login?next",
   authToken: "",
+  styleType: "grayscale",
+  showLoginIcon: true
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@conda-store/conda-store-ui": "^0.0.1-alpha.9",
+    "@conda-store/conda-store-ui": "^0.0.1-alpha.10",
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/apputils": "^3.1.0",
     "@jupyterlab/settingregistry": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-conda-store",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A jupyterlab extension that provides a beautiful, user-friendly graphical interface for building and managing environments using ayour existing conda-store server",
   "keywords": [
     "jupyter",
@@ -55,7 +55,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@conda-store/conda-store-ui": "^0.0.1-alpha.8",
+    "@conda-store/conda-store-ui": "^0.0.1-alpha.9",
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/apputils": "^3.1.0",
     "@jupyterlab/settingregistry": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@conda-store/conda-store-ui": "^0.0.1-alpha.10",
+    "@conda-store/conda-store-ui": "^0.0.1-alpha.11",
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/apputils": "^3.1.0",
     "@jupyterlab/settingregistry": "^3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jupyterlab-conda-store"
-version = "0.2.2"
+version = "0.2.3"
 description = "A jupyterlab extension that provides a beautiful, user-friendly graphical interface for building and managing environments using ayour existing conda-store server"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -5,8 +5,8 @@
   "jupyter.lab.menus": {
     "main": [
       {
-        "id": "jp-mainmenu-myextension",
-        "label": "conda store",
+        "id": "jp-mainmenu-jupyterlab-conda-store",
+        "label": "conda-store",
         "items": [
           {
             "command": "condastore:open",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -37,7 +37,7 @@
       "type": "string",
       "title": "conda-store login url",
       "description": "if using cookie-based authentication, the path to the login page. See the conda-store auth method option",
-      "default": "http://localhost:5000/conda-store/login?next"
+      "default": "http://localhost:5000/conda-store/login?next="
     },
     "authToken": {
       "type": "string",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,6 +2,19 @@
   "jupyter.lab.setting-icon": "conda-store:conda-store-icon",
   "jupyter.lab.setting-icon-label": "conda-store",
   "jupyter.lab.shortcuts": [],
+  "jupyter.lab.menus": {
+    "main": [
+      {
+        "id": "jp-mainmenu-settings",
+        "items": [
+          {
+            "command": "condastore:open",
+            "rank": 500
+          }
+        ]
+      }
+    ]
+  },
   "title": "jupyterlab-conda-store",
   "description": "jupyterlab-conda-store settings.",
   "type": "object",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -43,6 +43,19 @@
       "title": "conda-store auth token",
       "description": "if using token-based authentication, the value of said token. See the conda-store auth method option",
       "default": ""
+    },
+    "styleType": {
+      "type": "string",
+      "title": "conda-store app theme style",
+      "enum": ["grayscale", "green-accent"],
+      "description": "set the style theme of the app using the provided options.",
+      "default": "green-accent"
+    },
+    "showLoginIcon": {
+      "type": "boolean",
+      "title": "conda-store show icon login",
+      "description": "show or hide the login icon, which is located at the top",
+      "default": true
     }
   },
   "additionalProperties": false

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -5,7 +5,8 @@
   "jupyter.lab.menus": {
     "main": [
       {
-        "id": "jp-mainmenu-settings",
+        "id": "jp-mainmenu-myextension",
+        "label": "conda store",
         "items": [
           {
             "command": "condastore:open",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
 import { Widget } from '@lumino/widgets';
 import { CondaStoreWidget } from './widget';
+import { condaStoreNotextIcon } from './style';
 
 /**
  * Initialization data for the myextension extension.
@@ -39,7 +40,7 @@ async function activate(
 
     const command = 'condastore:open';
     app.commands.addCommand(command, {
-      label: 'Conda Store',
+      label: 'Initialize conda store',
       execute: () => {
         if (!widget || widget.isDisposed) {
           condaStoreExtension = new CondaStoreWidget(settings);
@@ -47,6 +48,8 @@ async function activate(
           widget.id = 'jp-conda-store';
           widget.title.label = 'conda-store';
           widget.title.closable = true;
+          condaStoreExtension.title.icon = condaStoreNotextIcon;
+          condaStoreExtension.title.caption = 'conda-store extension';
         }
 
         if (!widget.isAttached) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { CondaStoreWidget } from './widget';
 import { condaStoreNotextIcon } from './style';
 
 /**
- * Initialization data for the myextension extension.
+ * Initialization data for the jupyterlab-conda-store extension.
  */
 
 const plugin: JupyterFrontEndPlugin<void> = {
@@ -40,7 +40,7 @@ async function activate(
 
     const command = 'condastore:open';
     app.commands.addCommand(command, {
-      label: 'Initialize conda store',
+      label: 'Initialize conda-store',
       execute: () => {
         if (!widget || widget.isDisposed) {
           condaStoreExtension = new CondaStoreWidget(settings);

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,9 @@ async function activate(
           widget = new MainAreaWidget({ content: condaStoreExtension });
           widget.id = 'jp-conda-store';
           widget.title.label = 'conda-store';
+          widget.title.caption = 'conda-store extension';
+          widget.title.icon = condaStoreNotextIcon;
           widget.title.closable = true;
-          condaStoreExtension.title.icon = condaStoreNotextIcon;
-          condaStoreExtension.title.caption = 'conda-store extension';
         }
 
         if (!widget.isAttached) {

--- a/src/style/icons.ts
+++ b/src/style/icons.ts
@@ -6,10 +6,10 @@ import condaStoreNotextSvg from '../../style/icon/conda-store-notext-logo.svg';
 
 export const condaStoreIcon = new LabIcon({
   name: 'conda-store:conda-store-icon',
-  svgstr: condaStoreSvg,
+  svgstr: condaStoreSvg
 });
 
 export const condaStoreNotextIcon = new LabIcon({
   name: 'conda-store:conda-store-notext-icon',
-  svgstr: condaStoreNotextSvg,
+  svgstr: condaStoreNotextSvg
 });

--- a/src/style/index.ts
+++ b/src/style/index.ts
@@ -1,1 +1,1 @@
-export * from "./icons";
+export * from './icons';

--- a/src/widget/condaStoreWidget.tsx
+++ b/src/widget/condaStoreWidget.tsx
@@ -1,20 +1,19 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-import { App, IAppProps } from "@conda-store/conda-store-ui"
+import { App, IAppProps } from '@conda-store/conda-store-ui';
 import { ReactWidget } from '@jupyterlab/apputils';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-
 
 interface IJlabAppProps extends IAppProps {
   settings: ISettingRegistry.ISettings;
 }
 
 class JlabApp extends App<IJlabAppProps> {
-  constructor({settings}: IJlabAppProps) {
+  constructor({ settings }: IJlabAppProps) {
     super({
-      pref: settings.composite as IAppProps["pref"],
-      settings,
+      pref: settings.composite as IAppProps['pref'],
+      settings
     });
 
     this.settings = settings;
@@ -33,25 +32,23 @@ class JlabApp extends App<IJlabAppProps> {
   //   this.settings.changed.disconnect
   // }
 
-  settings: IJlabAppProps["settings"];
+  settings: IJlabAppProps['settings'];
 }
 
 export class CondaStoreWidget extends ReactWidget {
-  constructor(settings: IJlabAppProps["settings"]) {
+  constructor(settings: IJlabAppProps['settings']) {
     super();
     this.settings = settings;
   }
 
   render(): JSX.Element {
-    return (
-      <JlabApp settings={this.settings} />
-    );
+    return <JlabApp settings={this.settings} />;
   }
 
   rerender(): Promise<void> {
     return new Promise<void>(resolve => {
       ReactDOM.unmountComponentAtNode(this.node);
-      
+
       const vnode = this.render();
       if (vnode) {
         ReactDOM.render(vnode, this.node, resolve);
@@ -63,6 +60,5 @@ export class CondaStoreWidget extends ReactWidget {
     });
   }
 
-  settings: IJlabAppProps["settings"];
+  settings: IJlabAppProps['settings'];
 }
-

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -1,1 +1,1 @@
-export * from "./condaStoreWidget";
+export * from './condaStoreWidget';

--- a/style/icon/conda-store-notext-logo.svg
+++ b/style/icon/conda-store-notext-logo.svg
@@ -8,7 +8,7 @@
   <defs
      id="defs55">
     <style
-       id="style53">.cls-1{fill:#fff;}.cls-2{fill:#a8e29f;}.cls-3{fill:#40af2f;}</style>
+       id="style53">.cls-1{fill:#fff;}.cls-2{fill:#bdbdbd;}.cls-3{fill:#616161;}</style>
   </defs>
   <g
      id="g67"

--- a/ui-tests/tests/jupyterlab_conda_store.spec.ts
+++ b/ui-tests/tests/jupyterlab_conda_store.spec.ts
@@ -16,6 +16,8 @@ test('should emit an activation console message', async ({ page }) => {
   await page.goto();
 
   expect(
-    logs.filter(s => s === 'JupyterLab extension jupyterlab-conda-store is activated!')
+    logs.filter(
+      s => s === 'JupyterLab extension jupyterlab-conda-store is activated!'
+    )
   ).toHaveLength(1);
 });


### PR DESCRIPTION
- To improve user experience, move the extension from the left sidebar to the main area.
- Add additional props to customize the extension.
- Use the most recent conda-store-ui version: `0.0.1-alpha.11`

<img width="1412" alt="Screen Shot 2022-12-28 at 10 24 51 AM" src="https://user-images.githubusercontent.com/5192743/209834303-9366752c-96c1-4180-9532-8086781aaad4.png">
