### PR TITLE
Create the conda-store menu dinamically 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@conda-store/conda-store-ui": "^0.1.0",
     "@jupyterlab/application": "^3.1.0",
     "@jupyterlab/apputils": "^3.1.0",
+    "@jupyterlab/mainmenu": "^3.1.0",
     "@jupyterlab/settingregistry": "^3.1.0",
     "@jupyterlab/ui-components": "^3.1.0",
     "react": "^17.0.1",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -2,20 +2,6 @@
   "jupyter.lab.setting-icon": "conda-store:conda-store-icon",
   "jupyter.lab.setting-icon-label": "conda-store",
   "jupyter.lab.shortcuts": [],
-  "jupyter.lab.menus": {
-    "main": [
-      {
-        "id": "jp-mainmenu-jupyterlab-conda-store",
-        "label": "conda-store",
-        "items": [
-          {
-            "command": "condastore:open",
-            "rank": 500
-          }
-        ]
-      }
-    ]
-  },
   "title": "jupyterlab-conda-store",
   "description": "jupyterlab-conda-store settings.",
   "type": "object",
@@ -56,6 +42,12 @@
       "type": "boolean",
       "title": "conda-store show icon login",
       "description": "show or hide the login icon, which is located at the top",
+      "default": true
+    },
+    "addMainMenuItem": {
+      "type": "boolean",
+      "title": "conda-store menu item",
+      "description": "add the conda-store item to the main menu.",
       "default": true
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ async function activate(
         args: {}
       });
       mainMenu.addMenu(condaStoreMenu, { rank: 1000 });
+    } else {
+      mainMenu.settingsMenu.addGroup([{ command }], 900);
     }
   } catch (error) {
     console.error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ async function activate(
 
     const command = 'condastore:open';
     app.commands.addCommand(command, {
-      label: 'Conda Store Packages Manager',
+      label: 'Conda Store Package Manager',
       execute: () => {
         if (!widget || widget.isDisposed) {
           condaStoreExtension = new CondaStoreWidget(settings);
@@ -70,7 +70,7 @@ async function activate(
     // Create the conda-store top-level menu
     if (addCustomMenuItem) {
       const condaStoreMenu = new Menu({ commands: app.commands });
-      condaStoreMenu.title.label = 'Conda Store';
+      condaStoreMenu.title.label = 'Conda-Store';
       condaStoreMenu.addItem({
         command,
         args: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,31 +1,29 @@
 import {
-  ILayoutRestorer,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
-import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
-import { Widget } from '@lumino/widgets';
+import { IMainMenu } from '@jupyterlab/mainmenu';
+import { MainAreaWidget } from '@jupyterlab/apputils';
+import { Menu, Widget } from '@lumino/widgets';
 import { CondaStoreWidget } from './widget';
 import { condaStoreNotextIcon } from './style';
 
 /**
  * Initialization data for the jupyterlab-conda-store extension.
  */
-
 const plugin: JupyterFrontEndPlugin<void> = {
   activate,
   autoStart: true,
   id: 'jupyterlab-conda-store:plugin',
-  requires: [ISettingRegistry, ICommandPalette, ILayoutRestorer]
+  requires: [ISettingRegistry, IMainMenu]
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 async function activate(
   app: JupyterFrontEnd,
   settingRegistry: ISettingRegistry,
-  palette: ICommandPalette,
-  restorer: ILayoutRestorer
+  mainMenu: IMainMenu
 ) {
   console.log('JupyterLab extension conda-store is activated!');
 
@@ -37,10 +35,11 @@ async function activate(
 
   try {
     settings = await settingRegistry.load(plugin.id);
+    const addCustomMenuItem = settings?.composite.addMainMenuItem ?? true;
 
     const command = 'condastore:open';
     app.commands.addCommand(command, {
-      label: 'Initialize conda-store',
+      label: 'Conda Store Packages Manager',
       execute: () => {
         if (!widget || widget.isDisposed) {
           condaStoreExtension = new CondaStoreWidget(settings);
@@ -68,7 +67,16 @@ async function activate(
       }
     });
 
-    palette.addItem({ command, category: 'Extension' });
+    // Create the conda-store top-level menu
+    if (addCustomMenuItem) {
+      const condaStoreMenu = new Menu({ commands: app.commands });
+      condaStoreMenu.title.label = 'Conda Store';
+      condaStoreMenu.addItem({
+        command,
+        args: {}
+      });
+      mainMenu.addMenu(condaStoreMenu, { rank: 1000 });
+    }
   } catch (error) {
     console.error(
       'Failed to load settings for the conda-store Extension.\n%1',


### PR DESCRIPTION
By default, the extension creates a new conda-store menu at the top.

It is possible that some JupyterLab users do not want this ability; that is why we added an extra parameter to show or hide the conda-store menu.
_For Morningstar's purposes, we already have a menu where we are adding some utilities and extensions, and we don't want to generate a new one._
### Behavior
**The user can activate or deactivate the create menu feature by using the settings:**
<img width="326" alt="Screen Shot 2023-01-10 at 2 37 33 PM" src="https://user-images.githubusercontent.com/5192743/211646000-20a5a61b-13e1-4202-bd3a-e0132ccf6969.png">
**If the option is activated, a new menu labeled "Conda-Store" will be displayed:**
<img width="464" alt="Screen Shot 2023-01-10 at 2 37 59 PM" src="https://user-images.githubusercontent.com/5192743/211646551-7cc7285a-1f10-4d3a-b67d-5bfaf38fe134.png">
**If not, a new option will be added to the Settings menu instead of a new menu:**
<img width="289" alt="Screen Shot 2023-01-10 at 2 38 39 PM" src="https://user-images.githubusercontent.com/5192743/211646854-0cb7eeab-d991-4201-9247-65ee0dc0a39e.png">

