### PR TITLE
Automate pypi releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: '*'
+  workflow_call:
 
 jobs:
   build:
@@ -12,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -29,7 +30,7 @@ jobs:
     - name: Test the extension
       run: |
         set -eux
-        jlpm run test
+        jlpm run test --passWithNoTests
 
     - name: Build the extension
       run: |
@@ -46,13 +47,12 @@ jobs:
 
         pip install build
         python -m build
-        pip uninstall -y "jupyterlab_conda_store" jupyterlab
 
     - name: Upload extension packages
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: extension-artifacts
-        path: dist/jupyterlab_conda_store*
+        path: dist/
         if-no-files-found: error
 
   test_isolated:
@@ -61,15 +61,18 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v2
+
+    - uses: actions/download-artifact@v3
       with:
         name: extension-artifacts
+
     - name: Install and Test
       run: |
         set -eux

--- a/.github/workflows/build_and_deploy_release.yml
+++ b/.github/workflows/build_and_deploy_release.yml
@@ -1,0 +1,39 @@
+name: Build and Deploy Release
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - created
+      - published
+jobs:
+
+  call-build:
+    uses: Quansight/jupyterlab-conda-store/.github/workflows/build.yml@main
+
+  deploy-build:
+    runs-on: ubuntu-latest
+    if: always() # Runs despite playwright tests failing
+    needs: call-build
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Download extension package
+      uses: actions/download-artifact@v3
+      with:
+        name: extension-artifacts
+        path: dist/
+      
+    - name: Upload to pypi
+      run: |
+        set -eux
+        pip install twine
+        twine upload -r pypi dist/*
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD:  ${{ secrets.PYPI_PASSWORD }}
+       
+      
+        

--- a/.github/workflows/build_and_deploy_release.yml
+++ b/.github/workflows/build_and_deploy_release.yml
@@ -2,10 +2,9 @@ name: Build and Deploy Release
 
 on:
   workflow_dispatch:
-  release:
-    types:
-      - created
-      - published
+  push:
+    tags:        
+      - 'v*'          
 jobs:
 
   call-build:


### PR DESCRIPTION
This PR has some work to be done before being merged, namely: 

1) Remove the branches directive while deciding when to trigger the workflow
and
2) Upload to real upload.pypi.org instead of uploading to test.pypi.org, done by modifying the `twine upload` command to pypi instead of testpypi and then additionally swapping the secrets out as well. 

This PR addresses issue #5.